### PR TITLE
PHP JWT generation and authentication example

### DIFF
--- a/JWT/samples/adobe-jwt-php/AccessTokenProvider.php
+++ b/JWT/samples/adobe-jwt-php/AccessTokenProvider.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * Author: deepkamal.singh@adobe.com
+ * Date: 03/12/19
+ * Time: 16:46
+ */
+
+/**
+ * Class JWTProvider
+ * simple implementation
+ */
+class JWTProvider
+{
+
+    private const SIGN_ALGORITHM = 'RS256';
+
+    /**
+     * Converts and signs array into a JWT string.
+     *
+     * @param array $payload
+     * @param string $key
+     *
+     * @return string
+     * @throws \InvalidArgumentException
+     */
+    public function encode(array $payload, string $key)
+    {
+        $header = ['typ' => 'JWT', 'alg' => self::SIGN_ALGORITHM];
+
+        $headerJson = json_encode($header);
+        $segments[] = $this->urlSafeB64Encode($headerJson);
+
+        $payloadJson = json_encode($payload);
+        echo "Paylod JSON:\n" . $payloadJson . "\n\n";
+        $segments[] = $this->urlSafeB64Encode($payloadJson);
+
+        //now going to use openssl_sign()
+        $result = openssl_sign(implode('.', $segments),
+            $signature,
+            $key,
+            'sha256');
+        if (false === $result) {
+            throw new \RuntimeException('Failed to encrypt value. ' . implode("\n", $this->getSslErrors()));
+        }
+        $segments[] = $this->urlSafeB64Encode($signature);
+
+        return implode('.', $segments); //PACK THE ARRAY CONTAINING JWT
+
+    }
+
+    /**
+     * Encode a string with URL-safe Base64.
+     *
+     * @param string $input The string you want encoded
+     *
+     * @return string
+     */
+    private function urlSafeB64Encode(string $input): string
+    {
+        return str_replace('=', '', strtr(base64_encode($input), '+/', '-_'));
+    }
+
+
+    /**
+     * Builds request JWT.
+     *
+     * @param string $formattableTimeString
+     * @param string $issuer
+     * @param string $subject
+     * @param string $audience
+     * @param string $services
+     * @return string[]
+     */
+    public function buildJWTPayload($formattableTimeString, $issuer, $subject, $audience, $services)
+    {
+
+        $data = [
+            "exp" => strtotime($formattableTimeString),
+            "iss" => $issuer,
+            "sub" => $subject,
+            "aud" => $audience
+        ];
+
+        if (is_array($services)) {
+            foreach ($services as &$aService) {
+//                echo "Found service " . $aService . "\n";
+                $data[$aService] = true;
+            }
+        } else {
+            //assuming a single service
+            $data[$services] = true;
+        }
+
+        return $data;
+    }
+
+}
+
+const AUTH_ENDPOINT= "https://ims-na1.adobelogin.com/ims/exchange/jwt/"; //token auth Endpoint
+
+/** Authenticates with Adobe IO - returns Auth Response
+ * @param $jwt
+ * @param $client_id
+ * @param $client_secret
+ * @return mixed |
+ */
+function doAdobeIOAuth($jwt,$client_id,$client_secret){
+
+    $curl = curl_init();
+
+    curl_setopt($curl, CURLOPT_POST, 1);
+
+    curl_setopt($curl, CURLOPT_POSTFIELDS, array(
+        "client_id" => $client_id,
+        "client_secret" => $client_secret,
+        "jwt_token" => $jwt,
+
+    ));
+
+    curl_setopt($curl, CURLOPT_URL, AUTH_ENDPOINT);
+    curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+
+    $result = curl_exec($curl);
+
+    curl_close($curl);
+
+    return $result;
+}
+
+/** psvm - example implementation
+ *  Usage:
+ *      AccessTokenProvider.php -i <client-id> -s <client-secret> -k <key-file> -u <issuer> -b <subject> -a <audience> -c <services comma separated> -e <exp time, default 1 Day>"
+ */
+function psvm()
+{
+
+    $cl_options = ""
+        . "i:"       // Client Id
+        . "s:"       // Client Secret
+        . "k:"       // Key File path
+        . "u:"       // Issuer
+        . "b:"       // Subject
+        . "a:"       // Audience
+        . "c:"       // services
+        . "e::";     // expires
+
+    $show_usage = false;
+    $cmdLineOpts = getopt($cl_options);
+
+    if (isset($cmdLineOpts["i"])) {
+        $client_id = $cmdLineOpts["i"];
+        if (isset($cmdLineOpts["s"])) {
+            $client_secret = $cmdLineOpts["s"];
+            if (isset($cmdLineOpts["k"])) {
+                $key_file = $cmdLineOpts["k"];
+                echo "Key file is " . $key_file . "\n";
+                if (is_file($key_file) && is_readable($key_file)) {
+                    $fHandle = fopen($key_file, "r") or die("Unable to read the key file " . $key_file."\n");
+                    $private_key = fread($fHandle, filesize($key_file)) or die("Unable to read the key file " . $key_file."\n");
+                    fclose($fHandle);
+                    if (isset($cmdLineOpts["u"])) {             //Checking issuer
+                        $issuer = $cmdLineOpts["u"];
+                        if (isset($cmdLineOpts["b"])) {         //checking subject
+                            $subject = $cmdLineOpts["b"];
+                            if (isset($cmdLineOpts["a"])) {     //checking audience
+                                $audience = $cmdLineOpts["a"];
+                                if (isset($cmdLineOpts["c"])) { //checking services
+
+                                    $services = preg_split("/,/", $cmdLineOpts["c"]);
+
+                                    if (isset($cmdLineOpts["e"])) {
+                                        $exp_time = $cmdLineOpts["e"];
+                                    } else {
+                                        echo "exp_time not provided assuming 1 day\n";
+                                        $exp_time = '1 Day';
+                                    }
+
+                                    $jwtInstance = new JWTProvider();
+
+                                    $payload = $jwtInstance->buildJWTPayload($exp_time,
+                                        $issuer,
+                                        $subject,
+                                        $audience,
+                                        $services);
+
+                                    $jwt = $jwtInstance->encode($payload, $private_key);
+
+                                    echo "JWT Prepared:" . $jwt . "\n\n";
+
+                                    $result = doAdobeIOAuth($jwt,$client_id,$client_secret);
+
+                                    echo "Result of Auth:\n\n" . $result . "\n";
+                                } else {
+                                    echo "Services not provided\n";
+                                    $show_usage = true;
+
+                                }
+                            } else {
+                                echo "Audience not provided\n";
+                                $show_usage = true;
+                            }
+                        } else {
+                            echo "Subject not provided\n";
+                            $show_usage = true;
+
+                        }
+                    } else {
+                        echo "Issuer not provided\n";
+                        $show_usage = true;
+
+                    }
+                } else {
+                    echo "Unable to read the key file " . $key_file . '\n';
+                }
+            } else {
+                echo "Key file location not provided\n";
+                $show_usage = true;
+
+            }
+        } else {
+            echo "Client-secret not provided\n";
+            $show_usage = true;
+
+        }
+    } else {
+        echo "Client ID not provided\n";
+        $show_usage = true;
+
+    }
+
+    if ($show_usage) {
+        echo "Usage:\n  AccessTokenProvider.php -i <client-id> -s <client-secret> -k <key-file> -u <issuer> -b <subject> -a <audience> -c <services comma separated> -e <exp time, default 1 Day>";
+    }
+}
+
+psvm();
+exit(1);

--- a/JWT/samples/adobe-jwt-php/readme.md
+++ b/JWT/samples/adobe-jwt-php/readme.md
@@ -12,8 +12,8 @@ It also contains method `doAdobeIOAuth($jwt,$client_id,$client_secret)` which us
 
     **Usage**
     
-    ```AccessTokenProvider.php -i <client-id> -s <client-secret> -k <key-file> -u <issuer> -b <subject> -a <audience> -c <services, comma separated> -e <exp time, default 1 Day>```
+    ```AccessTokenProvider.php -i <client-id> -s <client-secret> -k <key-file> -u <issuer> -b <subject> -c <metascopes, comma separated> -e <exp time, default 1 Day>```
 
     **Example**
     
-    ```php JWT/samples/adobe-jwt-php/AccessTokenProvider.php -i"e1b8b4c4109c48....." -s"965f8635-........" -k"/Path/of/private.key" -u"DD0E3......@AdobeOrg" -b"D36......@techacct.adobe.com" -a"https://ims-na1.adobelogin.com/c/e1b8b4c....." -c"https://ims-na1.adobelogin.com/s/ent_reactor_sdk,https://ims-na1.adobelogin.com/s/ent_adobeio_sdk" -e"1 day"```
+    ```php JWT/samples/adobe-jwt-php/AccessTokenProvider.php -i"e1b8b4c4109c48....." -s"965f8635-........" -k"/Path/of/private.key" -u"DD0E3......@AdobeOrg" -b"D36......@techacct.adobe.com" -c"ent_reactor_sdk,ent_adobeio_sdk" -e"1 day"```

--- a/JWT/samples/adobe-jwt-php/readme.md
+++ b/JWT/samples/adobe-jwt-php/readme.md
@@ -1,0 +1,19 @@
+# PHP JWT Provider and auth example
+
+This PHP implementation to prepare JWT does not use any external library, it uses PHP `openssl_sign` and other functions available in PHP.
+It also contains method `doAdobeIOAuth($jwt,$client_id,$client_secret)` which uses prepared JWT to do an authentication on AdobeIO and fetch `access_token`
+
+**How To Run**
+1. Download and extract the repo
+
+2. Run PHP AccessTokenProvider.php to auth and get AdobeIO Access Token
+
+3. Execute below commands
+
+    **Usage**
+    
+    ```AccessTokenProvider.php -i <client-id> -s <client-secret> -k <key-file> -u <issuer> -b <subject> -a <audience> -c <services, comma separated> -e <exp time, default 1 Day>```
+
+    **Example**
+    
+    ```php JWT/samples/adobe-jwt-php/AccessTokenProvider.php -i"e1b8b4c4109c48....." -s"965f8635-........" -k"/Path/of/private.key" -u"DD0E3......@AdobeOrg" -b"D36......@techacct.adobe.com" -a"https://ims-na1.adobelogin.com/c/e1b8b4c....." -c"https://ims-na1.adobelogin.com/s/ent_reactor_sdk,https://ims-na1.adobelogin.com/s/ent_adobeio_sdk" -e"1 day"```

--- a/JWT/samples/adobe-jwt-php/readme.md
+++ b/JWT/samples/adobe-jwt-php/readme.md
@@ -1,9 +1,10 @@
 # PHP JWT Provider and auth example
 
-This PHP implementation to prepare JWT does not use any external library, it uses PHP `openssl_sign` and other functions available in PHP.
-It also contains method `doAdobeIOAuth($jwt,$client_id,$client_secret)` which uses prepared JWT to do an authentication on AdobeIO and fetch `access_token`
+This is a PHP implementation to prepare JWT and shows an example login to AdobeIO to obtain `access_token`, it does not use any external library and calls `openssl_sign` and other functions available in PHP to build JWT.
 
-**How To Run**
+The method `doAdobeIOAuth($jwt,$client_id,$client_secret)` should be used as reference for login, it uses prepared JWT to do an authentication on AdobeIO and fetch `access_token`.
+
+**To Run**
 1. Download and extract the repo
 
 2. Run PHP AccessTokenProvider.php to auth and get AdobeIO Access Token


### PR DESCRIPTION
1. contains PHP executable code and readme.md with instructions to execute.
2. `https://github.com/AdobeDocs/adobeio-auth/blob/stage/JWT/samples/samples.md` to be updated to include PHP example after this PR is merged.
