### PR TITLE
PHP sample code link added in `JWT/samples/samples.md` (#57)

### DIFF
--- a/JWT/samples/samples.md
+++ b/JWT/samples/samples.md
@@ -1,15 +1,18 @@
 ## Sample Code
 
-The following samples demonstrate JWT token generation and exchanging it with Adobe IMS endpoint to retrieve an access token.
+The following samples demonstrate JWT generation and exchanging it with Adobe IMS endpoint to retrieve an access token.
 
 ### Node.js Example
-[Github repo](https://github.com/AdobeDocs/adobeio-auth/tree/stage/JWT/samples/adobe-jwt-node) where you can find a complete sample Node.js code to generate a JWT token and exchanging it with Adobe IMS Endpoint to retrieve an access token.
+[Github repo](https://github.com/AdobeDocs/adobeio-auth/tree/stage/JWT/samples/adobe-jwt-node) where you can find a complete sample Node.js code to generate a JWT and exchanging it with Adobe IMS Endpoint to retrieve an access token.
 
 ### Java Example
-[Github repo](https://github.com/AdobeDocs/adobeio-auth/tree/stage/JWT/samples/adobe-jwt-java) where you can find a complete sample Java code to generate a JWT Token and exchanging it with Adobe IMS Endpoint to retrieve an access token.
+[Github repo](https://github.com/AdobeDocs/adobeio-auth/tree/stage/JWT/samples/adobe-jwt-java) where you can find a complete sample Java code to generate a JWT and exchanging it with Adobe IMS Endpoint to retrieve an access token.
 
 ### Python Example
-[Github repo](https://github.com/AdobeDocs/adobeio-auth/tree/stage/JWT/samples/adobe-jwt-python) where you can find a complete sample Python code to generate a JWT Token and exchanging it with Adobe IMS Endpoint to retrieve an access token.
+[Github repo](https://github.com/AdobeDocs/adobeio-auth/tree/stage/JWT/samples/adobe-jwt-python) where you can find a complete sample Python code to generate a JWT and exchanging it with Adobe IMS Endpoint to retrieve an access token.
 
 ### C#.NET Example
-[Github repo](https://github.com/AdobeDocs/adobeio-auth/tree/stage/JWT/samples/adobe-jwt-dotnet) where you can find a complete sample C#.NET code to generate a JWT Token and exchanging it with Adobe IMS Endpoint to retrieve an access token.
+[Github repo](https://github.com/AdobeDocs/adobeio-auth/tree/stage/JWT/samples/adobe-jwt-dotnet) where you can find a complete sample C#.NET code to generate a JWT and exchanging it with Adobe IMS Endpoint to retrieve an access token.
+
+### PHP Example
+[Github repo](https://github.com/AdobeDocs/adobeio-auth/tree/stage/JWT/samples/adobe-jwt-php) where you can find PHP code example for JWT creation and reference method that exchanges JWT with Adobe IMS Endpoint to retrieve an access token.


### PR DESCRIPTION
* PHP example repo link added

* 'JWT Token' term replaced wit just JWT

Co-authored-by: Deep Kamal Singh <deesingh@adobe.com>